### PR TITLE
Expand Stats for nerds: source→output codec + deep video/audio/cache detail

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1443,10 +1443,10 @@ public class PlayerActivity extends Activity {
             mediaSizeExecutor.execute(() -> {
                 final long size = computeMediaSizeBytes(contentResolver, sizeUri);
                 final PlayerActivity activity = activityRef.get();
-                if (activity != null && !activity.isFinishing()) {
+                if (activity != null && !activity.isFinishing() && !activity.isDestroyed()) {
                     activity.runOnUiThread(() -> {
                         final PlayerActivity act = activityRef.get();
-                        if (act != null && sizeUri.equals(act.mPrefs.mediaUri)) {
+                        if (act != null && !act.isDestroyed() && sizeUri.equals(act.mPrefs.mediaUri)) {
                             act.mediaSizeBytes = size;
                             if (act.statsForNerds != null) {
                                 act.statsForNerds.setMediaSizeBytes(size);
@@ -1579,9 +1579,13 @@ public class PlayerActivity extends Activity {
                 // give up
             }
         } else if ("file".equals(scheme) && uri.getPath() != null) {
-            long len = new java.io.File(uri.getPath()).length();
-            if (len > 0) {
-                return len;
+            try {
+                long len = new java.io.File(uri.getPath()).length();
+                if (len > 0) {
+                    return len;
+                }
+            } catch (Exception ignored) {
+                // inaccessible path → fall through
             }
         }
         return -1;

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1426,7 +1426,22 @@ public class PlayerActivity extends Activity {
 
         videoDecoderName = null;
         audioDecoderName = null;
-        mediaSizeBytes = computeMediaSizeBytes(mPrefs.mediaUri);
+        // Resolve media size off the main thread — content/SAF queries can be slow (cloud providers).
+        mediaSizeBytes = -1;
+        final Uri sizeUri = mPrefs.mediaUri;
+        if (sizeUri != null) {
+            new Thread(() -> {
+                final long size = computeMediaSizeBytes(sizeUri);
+                runOnUiThread(() -> {
+                    if (sizeUri.equals(mPrefs.mediaUri)) {
+                        mediaSizeBytes = size;
+                        if (statsForNerds != null) {
+                            statsForNerds.setMediaSizeBytes(size);
+                        }
+                    }
+                });
+            }, "media-size").start();
+        }
         if (statsOverlay != null) {
             statsForNerds = new StatsForNerds(player, statsOverlay);
             player.addAnalyticsListener(new AnalyticsListener() {
@@ -1519,17 +1534,34 @@ public class PlayerActivity extends Activity {
         if (uri == null) {
             return -1;
         }
-        try (android.os.ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "r")) {
-            if (pfd != null) {
-                long sz = pfd.getStatSize();
-                if (sz > 0) {
-                    return sz;
+        final String scheme = uri.getScheme();
+        if ("content".equals(scheme)) {
+            // Cheap metadata query first; avoids forcing a download on cloud-backed providers.
+            try (android.database.Cursor cursor = getContentResolver().query(
+                    uri, new String[]{android.provider.OpenableColumns.SIZE}, null, null, null)) {
+                if (cursor != null && cursor.moveToFirst()) {
+                    int idx = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE);
+                    if (idx != -1 && !cursor.isNull(idx)) {
+                        long sz = cursor.getLong(idx);
+                        if (sz > 0) {
+                            return sz;
+                        }
+                    }
                 }
+            } catch (Exception ignored) {
+                // fall through to fd
             }
-        } catch (Exception ignored) {
-            // fall through to file-scheme attempt
-        }
-        if ("file".equals(uri.getScheme()) && uri.getPath() != null) {
+            try (android.os.ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "r")) {
+                if (pfd != null) {
+                    long sz = pfd.getStatSize();
+                    if (sz > 0) {
+                        return sz;
+                    }
+                }
+            } catch (Exception ignored) {
+                // give up
+            }
+        } else if ("file".equals(scheme) && uri.getPath() != null) {
             long len = new java.io.File(uri.getPath()).length();
             if (len > 0) {
                 return len;

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1427,19 +1427,26 @@ public class PlayerActivity extends Activity {
         videoDecoderName = null;
         audioDecoderName = null;
         // Resolve media size off the main thread — content/SAF queries can be slow (cloud providers).
+        // Use the application ContentResolver + a WeakReference so a slow query can't retain the Activity.
         mediaSizeBytes = -1;
         final Uri sizeUri = mPrefs.mediaUri;
         if (sizeUri != null) {
+            final android.content.ContentResolver contentResolver = getApplicationContext().getContentResolver();
+            final java.lang.ref.WeakReference<PlayerActivity> activityRef = new java.lang.ref.WeakReference<>(this);
             new Thread(() -> {
-                final long size = computeMediaSizeBytes(sizeUri);
-                runOnUiThread(() -> {
-                    if (sizeUri.equals(mPrefs.mediaUri)) {
-                        mediaSizeBytes = size;
-                        if (statsForNerds != null) {
-                            statsForNerds.setMediaSizeBytes(size);
+                final long size = computeMediaSizeBytes(contentResolver, sizeUri);
+                final PlayerActivity activity = activityRef.get();
+                if (activity != null && !activity.isFinishing()) {
+                    activity.runOnUiThread(() -> {
+                        final PlayerActivity act = activityRef.get();
+                        if (act != null && sizeUri.equals(act.mPrefs.mediaUri)) {
+                            act.mediaSizeBytes = size;
+                            if (act.statsForNerds != null) {
+                                act.statsForNerds.setMediaSizeBytes(size);
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }, "media-size").start();
         }
         if (statsOverlay != null) {
@@ -1530,14 +1537,14 @@ public class PlayerActivity extends Activity {
         return null;
     }
 
-    private long computeMediaSizeBytes(android.net.Uri uri) {
+    private static long computeMediaSizeBytes(android.content.ContentResolver contentResolver, android.net.Uri uri) {
         if (uri == null) {
             return -1;
         }
         final String scheme = uri.getScheme();
         if ("content".equals(scheme)) {
             // Cheap metadata query first; avoids forcing a download on cloud-backed providers.
-            try (android.database.Cursor cursor = getContentResolver().query(
+            try (android.database.Cursor cursor = contentResolver.query(
                     uri, new String[]{android.provider.OpenableColumns.SIZE}, null, null, null)) {
                 if (cursor != null && cursor.moveToFirst()) {
                     int idx = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE);
@@ -1551,7 +1558,7 @@ public class PlayerActivity extends Activity {
             } catch (Exception ignored) {
                 // fall through to fd
             }
-            try (android.os.ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "r")) {
+            try (android.os.ParcelFileDescriptor pfd = contentResolver.openFileDescriptor(uri, "r")) {
                 if (pfd != null) {
                     long sz = pfd.getStatSize();
                     if (sz > 0) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1517,6 +1517,9 @@ public class PlayerActivity extends Activity {
         statsForNerds.setTunneling(mPrefs.tunneling);
         statsForNerds.setBackBufferSeconds(mPrefs.bufferBack);
         statsForNerds.setMediaSizeBytes(mediaSizeBytes);
+        statsForNerds.setNetwork(Utils.isSupportedNetworkUri(mPrefs.mediaUri));
+        statsForNerds.setBandwidthMeter(
+                androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.getSingletonInstance(this));
     }
 
     /** Whether DV7→8.1 conversion should run for this playback (auto = only when device needs it). */

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -175,6 +175,13 @@ public class PlayerActivity extends Activity {
     private TextView statsOverlay;
     private StatsForNerds statsForNerds;
     private boolean statsVisible;
+    // Shared single daemon thread for media-size queries (no per-playback thread churn).
+    private static final java.util.concurrent.ExecutorService mediaSizeExecutor =
+            java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "media-size");
+                t.setDaemon(true);
+                return t;
+            });
     private long mediaSizeBytes = -1;
     private String videoDecoderName;
     private String audioDecoderName;
@@ -1433,7 +1440,7 @@ public class PlayerActivity extends Activity {
         if (sizeUri != null) {
             final android.content.ContentResolver contentResolver = getApplicationContext().getContentResolver();
             final java.lang.ref.WeakReference<PlayerActivity> activityRef = new java.lang.ref.WeakReference<>(this);
-            new Thread(() -> {
+            mediaSizeExecutor.execute(() -> {
                 final long size = computeMediaSizeBytes(contentResolver, sizeUri);
                 final PlayerActivity activity = activityRef.get();
                 if (activity != null && !activity.isFinishing()) {
@@ -1447,7 +1454,7 @@ public class PlayerActivity extends Activity {
                         }
                     });
                 }
-            }, "media-size").start();
+            });
         }
         if (statsOverlay != null) {
             statsForNerds = new StatsForNerds(player, statsOverlay);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -175,6 +175,7 @@ public class PlayerActivity extends Activity {
     private TextView statsOverlay;
     private StatsForNerds statsForNerds;
     private boolean statsVisible;
+    private long mediaSizeBytes = -1;
     private String videoDecoderName;
     private String audioDecoderName;
     private ProgressBar loadingProgressBar;
@@ -1425,6 +1426,7 @@ public class PlayerActivity extends Activity {
 
         videoDecoderName = null;
         audioDecoderName = null;
+        mediaSizeBytes = computeMediaSizeBytes(mPrefs.mediaUri);
         if (statsOverlay != null) {
             statsForNerds = new StatsForNerds(player, statsOverlay);
             player.addAnalyticsListener(new AnalyticsListener() {
@@ -1483,6 +1485,9 @@ public class PlayerActivity extends Activity {
         statsForNerds.setVideoDecoder(videoDecoderName);
         statsForNerds.setAudioDecoder(audioDecoderName);
         statsForNerds.setProcessing(buildProcessingInfo());
+        statsForNerds.setTunneling(mPrefs.tunneling);
+        statsForNerds.setBackBufferSeconds(mPrefs.bufferBack);
+        statsForNerds.setMediaSizeBytes(mediaSizeBytes);
     }
 
     /** Whether DV7→8.1 conversion should run for this playback (auto = only when device needs it). */
@@ -1498,27 +1503,39 @@ public class PlayerActivity extends Activity {
         }
     }
 
-    // "What the app is doing to the video to get it playing."
+    // "What the app is actively doing to the stream." Null (suppressed) unless really converting.
     private String buildProcessingInfo() {
-        final List<String> parts = new ArrayList<>();
         final Integer convertedFrom = DolbyVisionConversionStats.getLastSourceProfile();
         if (convertedFrom != null && DoviBridge.getConversionSuccessCount() > 0) {
             final Integer mode = DolbyVisionConversionStats.getLastSelectedConversionMode();
-            parts.add("DV" + convertedFrom + "→8.1 converting"
+            return "DV" + convertedFrom + "→8.1 converting"
                     + (mode != null ? " (mode " + mode + ")" : "")
-                    + ", " + DoviBridge.getConversionSuccessCount() + " RPUs");
-        } else if (dv7to81ConversionActive()) {
-            parts.add("DV7→8.1 armed");
-        } else if (mPrefs.mapDV7ToHevc) {
-            parts.add("DV7→HDR10 fallback");
+                    + ", " + DoviBridge.getConversionSuccessCount() + " RPUs";
         }
-        if (mPrefs.tunneling) {
-            parts.add("tunneling");
+        return null;
+    }
+
+    private long computeMediaSizeBytes(android.net.Uri uri) {
+        if (uri == null) {
+            return -1;
         }
-        if (parts.isEmpty()) {
-            return "direct play (no conversion)";
+        try (android.os.ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "r")) {
+            if (pfd != null) {
+                long sz = pfd.getStatSize();
+                if (sz > 0) {
+                    return sz;
+                }
+            }
+        } catch (Exception ignored) {
+            // fall through to file-scheme attempt
         }
-        return TextUtils.join(", ", parts);
+        if ("file".equals(uri.getScheme()) && uri.getPath() != null) {
+            long len = new java.io.File(uri.getPath()).length();
+            if (len > 0) {
+                return len;
+            }
+        }
+        return -1;
     }
 
     private void savePlayer() {

--- a/app/src/main/java/com/brouken/player/StatsForNerds.java
+++ b/app/src/main/java/com/brouken/player/StatsForNerds.java
@@ -116,7 +116,8 @@ class StatsForNerds extends DebugTextViewHelper {
         }
         row(sb, "Video", v.toString());
 
-        row(sb, "HDR", hdrLabel(f) + "   " + colorLabel(f));
+        String color = colorLabel(f);
+        row(sb, "HDR", hdrLabel(f) + (color.isEmpty() ? "" : "   " + color));
 
         String dec = decoderLabel(videoDecoder);
         if (tunneling) {

--- a/app/src/main/java/com/brouken/player/StatsForNerds.java
+++ b/app/src/main/java/com/brouken/player/StatsForNerds.java
@@ -1,29 +1,44 @@
 package com.brouken.player;
 
+import android.text.TextUtils;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
+import androidx.media3.common.Tracks;
+import androidx.media3.exoplayer.DecoderCounters;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.util.DebugTextViewHelper;
 
+import com.brouken.player.dv.DolbyVisionConversionStats;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 /**
- * "Stats for nerds" overlay: shows what the video is and what the app is doing to play it.
- * Builds on Media3's {@link DebugTextViewHelper} (which gives us the 1s auto-refresh loop) but
- * replaces the debug string with a trimmed, human-readable "essentials" panel.
+ * "Stats for nerds" overlay: a labeled panel showing what the video is and what the app is doing
+ * to play it. Builds on Media3's {@link DebugTextViewHelper} for the 1s auto-refresh loop, but
+ * renders its own human-readable, multi-group panel.
+ *
+ * <p>For DV7→8.1 playback the video line shows the source→output codec, since the player only sees
+ * the rewritten format ({@link DolbyVisionConversionStats#getLastSourceCodec()} supplies the
+ * original).
  */
 class StatsForNerds extends DebugTextViewHelper {
+
+    private static final int LABEL_WIDTH = 8;
 
     private final ExoPlayer player;
 
     @Nullable private String videoDecoder;
     @Nullable private String audioDecoder;
-    // "What the app is doing to it" — e.g. DV conversion state, tunneling. Set by PlayerActivity.
     @Nullable private String processing;
+    private boolean tunneling;
+    private int backBufferSeconds;
+    private long mediaSizeBytes = -1;
 
     StatsForNerds(ExoPlayer player, TextView textView) {
         super(player, textView);
@@ -42,54 +57,146 @@ class StatsForNerds extends DebugTextViewHelper {
         this.processing = processing;
     }
 
+    void setTunneling(boolean tunneling) {
+        this.tunneling = tunneling;
+    }
+
+    void setBackBufferSeconds(int backBufferSeconds) {
+        this.backBufferSeconds = backBufferSeconds;
+    }
+
+    void setMediaSizeBytes(long mediaSizeBytes) {
+        this.mediaSizeBytes = mediaSizeBytes;
+    }
+
     @Override
     protected String getDebugString() {
         StringBuilder sb = new StringBuilder();
         appendVideo(sb);
         appendAudio(sb);
+        appendPlayback(sb);
         appendProcessing(sb);
         return sb.toString();
+    }
+
+    private void row(StringBuilder sb, String label, String value) {
+        sb.append(String.format(Locale.US, "%-" + LABEL_WIDTH + "s", label)).append(value).append('\n');
     }
 
     private void appendVideo(StringBuilder sb) {
         Format f = player.getVideoFormat();
         if (f == null) {
-            sb.append("Video: —\n");
+            row(sb, "Video", "—");
             return;
         }
-        sb.append("Video: ");
-        sb.append(codecLabel(f.sampleMimeType, f.codecs));
+        StringBuilder v = new StringBuilder();
+        String sourceCodec = DolbyVisionConversionStats.getLastSourceCodec();
+        if (sourceCodec != null && f.codecs != null && !sourceCodec.equalsIgnoreCase(f.codecs)) {
+            // Symmetric, tight codec pair (mime is implied by the HDR line): dvhe.07.06 → dvhe.08.06
+            v.append(sourceCodec).append(" → ").append(f.codecs);
+        } else {
+            v.append(codecLabel(f.sampleMimeType, f.codecs));
+        }
         if (f.width != Format.NO_VALUE && f.height != Format.NO_VALUE) {
-            sb.append(' ').append(f.width).append('x').append(f.height);
+            v.append("  ").append(f.width).append('x').append(f.height);
         }
         if (f.frameRate != Format.NO_VALUE && f.frameRate > 0) {
-            sb.append(String.format(Locale.US, " @%.3ffps", f.frameRate));
+            v.append(String.format(Locale.US, " @%.3f", f.frameRate));
         }
-        sb.append('\n');
-        sb.append("HDR: ").append(hdrLabel(f)).append('\n');
-        sb.append("Decoder: ").append(decoderLabel(videoDecoder)).append('\n');
+        row(sb, "Video", v.toString());
+
+        row(sb, "HDR", hdrLabel(f) + "   " + colorLabel(f));
+
+        String dec = decoderLabel(videoDecoder);
+        if (tunneling) {
+            dec = dec.endsWith(")") ? dec.substring(0, dec.length() - 1) + ", tunneled)" : dec + " (tunneled)";
+        }
+        row(sb, "Decoder", dec);
+
+        DecoderCounters c = player.getVideoDecoderCounters();
+        if (c != null) {
+            row(sb, "Frames", "rendered " + c.renderedOutputBufferCount
+                    + "  dropped " + c.droppedBufferCount
+                    + "  skipped " + c.skippedOutputBufferCount);
+        }
+
+        StringBuilder b = new StringBuilder(bitrateLabel(f));
+        if (f.pixelWidthHeightRatio != Format.NO_VALUE && f.pixelWidthHeightRatio > 0) {
+            b.append(String.format(Locale.US, "   PAR %.2f", f.pixelWidthHeightRatio));
+        }
+        b.append("  rot ").append(f.rotationDegrees == Format.NO_VALUE ? 0 : f.rotationDegrees).append('°');
+        row(sb, "Bitrate", b.toString());
     }
 
     private void appendAudio(StringBuilder sb) {
         Format f = player.getAudioFormat();
         if (f == null) {
-            sb.append("Audio: —\n");
-            return;
+            row(sb, "Audio", "—");
+        } else {
+            StringBuilder a = new StringBuilder(codecLabel(f.sampleMimeType, f.codecs));
+            if (f.channelCount != Format.NO_VALUE) {
+                a.append(' ').append(f.channelCount).append("ch");
+            }
+            if (f.sampleRate != Format.NO_VALUE) {
+                a.append(' ').append(f.sampleRate).append("Hz");
+            }
+            int abr = f.bitrate != Format.NO_VALUE ? f.bitrate : f.averageBitrate;
+            if (abr != Format.NO_VALUE && abr > 0) {
+                a.append(' ').append(Math.round(abr / 1000f)).append("kbps");
+            }
+            a.append(" [").append(decoderLabel(audioDecoder)).append(']');
+            if (!TextUtils.isEmpty(f.language)) {
+                a.append(' ').append(f.language);
+            }
+            row(sb, "Audio", a.toString());
         }
-        sb.append("Audio: ");
-        sb.append(codecLabel(f.sampleMimeType, f.codecs));
-        if (f.channelCount != Format.NO_VALUE) {
-            sb.append(' ').append(f.channelCount).append("ch");
+        appendAudioTracks(sb);
+    }
+
+    private void appendAudioTracks(StringBuilder sb) {
+        Tracks tracks = player.getCurrentTracks();
+        List<String> entries = new ArrayList<>();
+        int total = 0;
+        int selectedOrdinal = 0;
+        for (Tracks.Group group : tracks.getGroups()) {
+            if (group.getType() != C.TRACK_TYPE_AUDIO) {
+                continue;
+            }
+            for (int i = 0; i < group.length; i++) {
+                total++;
+                Format tf = group.getTrackFormat(i);
+                boolean selected = group.isTrackSelected(i);
+                if (selected) {
+                    selectedOrdinal = total;
+                }
+                StringBuilder e = new StringBuilder(selected ? "▶" : "·");
+                e.append(TextUtils.isEmpty(tf.language) ? "und" : tf.language);
+                e.append(' ').append(codecLabel(tf.sampleMimeType, null));
+                if (tf.channelCount != Format.NO_VALUE) {
+                    e.append(' ').append(tf.channelCount).append("ch");
+                }
+                entries.add(e.toString());
+            }
         }
-        if (f.sampleRate != Format.NO_VALUE) {
-            sb.append(' ').append(f.sampleRate).append("Hz");
+        if (total > 1) {
+            row(sb, "Tracks", TextUtils.join("  ", entries) + "  (" + selectedOrdinal + "/" + total + ")");
         }
-        sb.append(" [").append(decoderLabel(audioDecoder)).append("]\n");
+    }
+
+    private void appendPlayback(StringBuilder sb) {
+        long pos = player.getCurrentPosition();
+        long buffered = player.getBufferedPosition();
+        long aheadMs = Math.max(0, buffered - pos);
+        float speed = player.getPlaybackParameters().speed;
+        row(sb, "Cache", String.format(Locale.US, "+%ds ahead / %ds back    speed %.2fx",
+                aheadMs / 1000, backBufferSeconds, speed));
+        long dur = player.getDuration();
+        row(sb, "Time", formatTime(pos) + " / " + (dur == C.TIME_UNSET ? "—" : formatTime(dur)));
     }
 
     private void appendProcessing(StringBuilder sb) {
         if (processing != null && !processing.isEmpty()) {
-            sb.append("Doing: ").append(processing);
+            sb.append(String.format(Locale.US, "%-" + LABEL_WIDTH + "s", "Doing")).append(processing);
         }
     }
 
@@ -99,6 +206,80 @@ class StatsForNerds extends DebugTextViewHelper {
             return mime + " (" + codecs + ")";
         }
         return mime;
+    }
+
+    private static String colorLabel(Format f) {
+        ColorInfo color = f.colorInfo;
+        List<String> parts = new ArrayList<>();
+        if (color != null) {
+            switch (color.colorSpace) {
+                case C.COLOR_SPACE_BT2020: parts.add("BT2020"); break;
+                case C.COLOR_SPACE_BT709: parts.add("BT709"); break;
+                case C.COLOR_SPACE_BT601: parts.add("BT601"); break;
+                default: break;
+            }
+            switch (color.colorTransfer) {
+                case C.COLOR_TRANSFER_ST2084: parts.add("PQ"); break;
+                case C.COLOR_TRANSFER_HLG: parts.add("HLG"); break;
+                case C.COLOR_TRANSFER_SDR: parts.add("SDR"); break;
+                default: break;
+            }
+            if (color.colorRange == C.COLOR_RANGE_FULL) {
+                parts.add("full");
+            } else if (color.colorRange == C.COLOR_RANGE_LIMITED) {
+                parts.add("limited");
+            }
+        }
+        int depth = bitDepth(f);
+        if (depth > 0) {
+            parts.add(depth + "-bit");
+        }
+        return parts.isEmpty() ? "" : TextUtils.join("/", parts);
+    }
+
+    private static int bitDepth(Format f) {
+        ColorInfo color = f.colorInfo;
+        if (color != null && color.lumaBitdepth != Format.NO_VALUE && color.lumaBitdepth > 0) {
+            return color.lumaBitdepth;
+        }
+        String codecs = f.codecs == null ? "" : f.codecs.toLowerCase(Locale.US);
+        if (codecs.startsWith("dvhe") || codecs.startsWith("dvh1")
+                || codecs.contains("hvc1.2") || codecs.contains("hev1.2")) {
+            return 10;
+        }
+        if (color != null
+                && (color.colorTransfer == C.COLOR_TRANSFER_ST2084 || color.colorTransfer == C.COLOR_TRANSFER_HLG)) {
+            return 10;
+        }
+        return 0;
+    }
+
+    /** Per-stream bitrate if the Format carries one, else an overall estimate (size ÷ duration). */
+    private String bitrateLabel(Format f) {
+        int br = f.bitrate != Format.NO_VALUE ? f.bitrate : f.averageBitrate;
+        if (br != Format.NO_VALUE && br > 0) {
+            return String.format(Locale.US, "~%.1f Mbps", br / 1_000_000f);
+        }
+        long dur = player.getDuration();
+        if (mediaSizeBytes > 0 && dur > 0 && dur != C.TIME_UNSET) {
+            double mbps = (mediaSizeBytes * 8000.0) / dur / 1_000_000.0;
+            return String.format(Locale.US, "~%.1f Mbps (overall)", mbps);
+        }
+        return "—";
+    }
+
+    private static String formatTime(long ms) {
+        if (ms < 0) {
+            ms = 0;
+        }
+        long totalSec = ms / 1000;
+        long h = totalSec / 3600;
+        long m = (totalSec % 3600) / 60;
+        long s = totalSec % 60;
+        if (h > 0) {
+            return String.format(Locale.US, "%d:%02d:%02d", h, m, s);
+        }
+        return String.format(Locale.US, "%02d:%02d", m, s);
     }
 
     private static String hdrLabel(Format f) {

--- a/app/src/main/java/com/brouken/player/StatsForNerds.java
+++ b/app/src/main/java/com/brouken/player/StatsForNerds.java
@@ -10,6 +10,7 @@ import androidx.media3.common.Format;
 import androidx.media3.common.Tracks;
 import androidx.media3.exoplayer.DecoderCounters;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.upstream.BandwidthMeter;
 import androidx.media3.exoplayer.util.DebugTextViewHelper;
 
 import com.brouken.player.dv.DolbyVisionConversionStats;
@@ -39,6 +40,8 @@ class StatsForNerds extends DebugTextViewHelper {
     private boolean tunneling;
     private int backBufferSeconds;
     private long mediaSizeBytes = -1;
+    private boolean network;
+    @Nullable private BandwidthMeter bandwidthMeter;
 
     StatsForNerds(ExoPlayer player, TextView textView) {
         super(player, textView);
@@ -67,6 +70,14 @@ class StatsForNerds extends DebugTextViewHelper {
 
     void setMediaSizeBytes(long mediaSizeBytes) {
         this.mediaSizeBytes = mediaSizeBytes;
+    }
+
+    void setNetwork(boolean network) {
+        this.network = network;
+    }
+
+    void setBandwidthMeter(@Nullable BandwidthMeter bandwidthMeter) {
+        this.bandwidthMeter = bandwidthMeter;
     }
 
     @Override
@@ -192,6 +203,13 @@ class StatsForNerds extends DebugTextViewHelper {
                 aheadMs / 1000, backBufferSeconds, speed));
         long dur = player.getDuration();
         row(sb, "Time", formatTime(pos) + " / " + (dur == C.TIME_UNSET ? "—" : formatTime(dur)));
+        // Measured network throughput (connection speed) — only meaningful for network streams.
+        if (network && bandwidthMeter != null) {
+            long bps = bandwidthMeter.getBitrateEstimate();
+            if (bps > 0) {
+                row(sb, "Net", String.format(Locale.US, "~%.1f Mbps (measured)", bps / 1_000_000f));
+            }
+        }
     }
 
     private void appendProcessing(StringBuilder sb) {

--- a/app/src/main/java/com/brouken/player/dv/DolbyVisionConversionStats.java
+++ b/app/src/main/java/com/brouken/player/dv/DolbyVisionConversionStats.java
@@ -12,6 +12,7 @@ public final class DolbyVisionConversionStats {
     private static final AtomicLong codecStringRewriteCount = new AtomicLong(0L);
     private static volatile Integer lastSourceProfile;
     private static volatile Integer lastConversionMode;
+    private static volatile String lastSourceCodec;
 
     private DolbyVisionConversionStats() {
     }
@@ -20,6 +21,7 @@ public final class DolbyVisionConversionStats {
         codecStringRewriteCount.set(0L);
         lastSourceProfile = null;
         lastConversionMode = null;
+        lastSourceCodec = null;
     }
 
     /** Records the SOURCE DV profile (pre-conversion), e.g. 7. */
@@ -27,6 +29,17 @@ public final class DolbyVisionConversionStats {
         if (profile != null) {
             lastSourceProfile = profile;
         }
+    }
+
+    /** Records the SOURCE codec string (pre-conversion), e.g. "dvhe.07.06". */
+    public static void recordSourceCodec(String codecs) {
+        if (codecs != null && !codecs.isEmpty()) {
+            lastSourceCodec = codecs;
+        }
+    }
+
+    public static String getLastSourceCodec() {
+        return lastSourceCodec;
     }
 
     public static void recordConversionMode(int mode) {

--- a/app/src/main/java/com/brouken/player/dv/DolbyVisionExtractorsFactory.java
+++ b/app/src/main/java/com/brouken/player/dv/DolbyVisionExtractorsFactory.java
@@ -272,6 +272,7 @@ public final class DolbyVisionExtractorsFactory implements ExtractorsFactory {
             Format outFormat = format;
             if (converting) {
                 DolbyVisionConversionStats.recordSourceProfile(profile);
+                DolbyVisionConversionStats.recordSourceCodec(format.codecs);
                 String rewritten = rewriteDvCodecString(format.codecs);
                 if (rewritten != null && !rewritten.equals(format.codecs)) {
                     outFormat = format.buildUpon().setCodecs(rewritten).build();

--- a/app/src/main/java/com/brouken/player/dv/DolbyVisionMatroskaTransformer.java
+++ b/app/src/main/java/com/brouken/player/dv/DolbyVisionMatroskaTransformer.java
@@ -118,6 +118,7 @@ public final class DolbyVisionMatroskaTransformer implements MatroskaExtractor.D
             return null;
         }
         DolbyVisionConversionStats.recordSourceProfile(profile);
+        DolbyVisionConversionStats.recordSourceCodec(codecs);
         String normalized = normalizeDolbyVisionCodecString(codecs);
         if (normalized != null && !normalized.equals(codecs)) {
             DolbyVisionConversionStats.recordCodecStringRewrite();

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -24,7 +24,7 @@
         android:padding="8dp"
         android:fontFamily="monospace"
         android:textColor="@color/exo_white"
-        android:textSize="12sp"
+        android:textSize="11sp"
         android:lineSpacingMultiplier="1.1"
         android:clickable="false"
         android:focusable="false"

--- a/app/src/main/res/layout/activity_player_textureview.xml
+++ b/app/src/main/res/layout/activity_player_textureview.xml
@@ -23,7 +23,7 @@
         android:padding="8dp"
         android:fontFamily="monospace"
         android:textColor="@color/exo_white"
-        android:textSize="12sp"
+        android:textSize="11sp"
         android:lineSpacingMultiplier="1.1"
         android:clickable="false"
         android:focusable="false"


### PR DESCRIPTION
Expands the **Stats for nerds** overlay into a labeled, detailed panel.

## What's new
- **Source → output codec** — shows the pre-conversion codec for DV7→8.1 playback, e.g. `dvhe.07.06 → dvhe.08.06`. The player only sees the rewritten format, so the original profile-7 codec is captured in `DolbyVisionConversionStats` at both conversion sites (MP4/TS factory + MKV transformer).
- **Video deep detail** — color space/transfer/range + bit depth, live rendered/dropped/skipped frame counters, PAR, rotation.
- **Audio deep detail** — bitrate + language on the selected track, plus a full audio-track listing with the selected one marked and `(selected/total)`.
- **Playback & cache** — buffered-ahead seconds (forward cache fill), configured back-buffer, speed, position/duration.
- **Bitrate fallback** — when the `Format` has no bitrate (common for remuxes/WEB-DL), estimate the overall rate from file size ÷ duration, labeled `(overall)`.
- **"Doing" line** — suppressed unless DV7→8.1 conversion is actually running (no more "armed"/"direct play" noise on plain files).
- Overlay text 12sp→11sp for the taller panel.

## Verification
Built (`assembleLatestUniversalDebug`) and verified on a Xiaomi Pad 6:
- DV7 MKV → `dvhe.07.06 → dvhe.08.06`, `Doing  DV7→8.1 converting (mode 2), N RPUs`.
- 1080p AVC SDR WEB-DL → `~4.3 Mbps (overall)`, no "Doing" line, 4-track audio list with the selected track marked.